### PR TITLE
Feature: Bilateral Filter

### DIFF
--- a/ascii_mapper/Filters/BilateralFilter.cs
+++ b/ascii_mapper/Filters/BilateralFilter.cs
@@ -27,6 +27,38 @@ namespace ascii_mapper.Filters
             int width = image.Width;
             int height = image.Height;
 
+            for (int i = 0; i < height; i++)
+            {
+                for (int j = 0; j < width; j++)
+                {
+                    double windowSum = 0;
+                    double kernel_sum = 0;
+                    int centerPixelIntensity = image.GetPixel(j, i).R; // Assuming grayscale image
+
+                    for (int windowY = 0; windowY < _spatialKernel.Diameter; windowY++)
+                    {
+                        for (int windowX = 0; windowX < _spatialKernel.Diameter; windowX++)
+                        {
+                            int x = KernelMath.Bounce(j + windowX - _spatialKernel.Radius, width - 1);
+                            int y = KernelMath.Bounce(i + windowY - _spatialKernel.Radius, height - 1);
+
+                            int neighborPixelIntensity = image.GetPixel(x, y).R; // Assuming grayscale image
+
+                            // Not materializing range kernel as an array, calculating inline during accumulation to reduce computational complexity
+                            double rangeWeight = _spatialKernel.Kernel[windowY * (_spatialKernel.Diameter - 1) + windowX] * KernelMath.Gaussian1D(neighborPixelIntensity, _rangeKernel.StandardDeviation, centerPixelIntensity);
+
+                            windowSum += rangeWeight * neighborPixelIntensity;
+                            kernel_sum += rangeWeight;
+                        }
+                    }
+
+                    windowSum /= kernel_sum;
+                    windowSum = Math.Min(255, Math.Max(0, windowSum)); // Clamp to [0, 255]
+
+                    filteredImage.SetPixel(j, i, Color.FromArgb((int)windowSum, (int)windowSum, (int)windowSum)); // Set the new pixel value
+                }
+            }
+
             return filteredImage;
         }
 

--- a/ascii_mapper/Form1.Designer.cs
+++ b/ascii_mapper/Form1.Designer.cs
@@ -35,6 +35,7 @@
             this.DownscaleButton = new System.Windows.Forms.Button();
             this.UndoButton = new System.Windows.Forms.Button();
             this.BlurButton = new System.Windows.Forms.Button();
+            this.BilateralFilterButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.TrackBar1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
@@ -110,11 +111,22 @@
             this.BlurButton.UseVisualStyleBackColor = true;
             this.BlurButton.Click += new System.EventHandler(this.BlurButton_Click);
             // 
+            // BilateralFilterButton
+            // 
+            this.BilateralFilterButton.Location = new System.Drawing.Point(13, 134);
+            this.BilateralFilterButton.Name = "BilateralFilterButton";
+            this.BilateralFilterButton.Size = new System.Drawing.Size(120, 23);
+            this.BilateralFilterButton.TabIndex = 7;
+            this.BilateralFilterButton.Text = "Bilateral Filter";
+            this.BilateralFilterButton.UseVisualStyleBackColor = true;
+            this.BilateralFilterButton.Click += new System.EventHandler(this.BilateralFilterButton_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1518, 929);
+            this.Controls.Add(this.BilateralFilterButton);
             this.Controls.Add(this.BlurButton);
             this.Controls.Add(this.UndoButton);
             this.Controls.Add(this.DownscaleButton);
@@ -140,6 +152,7 @@
         private System.Windows.Forms.Button DownscaleButton;
         private System.Windows.Forms.Button UndoButton;
         private System.Windows.Forms.Button BlurButton;
+        private System.Windows.Forms.Button BilateralFilterButton;
     }
 }
 

--- a/ascii_mapper/Form1.cs
+++ b/ascii_mapper/Form1.cs
@@ -73,5 +73,11 @@ namespace ascii_mapper
             imageWrapper.ApplyFilter(new Filters.GaussianBlurFilter(5.0));
             pictureBox1.Image = imageWrapper.Image;
         }
+
+        private void BilateralFilterButton_Click(object sender, EventArgs e)
+        {
+            imageWrapper.ApplyFilter(new Filters.BilateralFilter(5.0, 5.0));
+            pictureBox1.Image = imageWrapper.Image;
+        }
     }
 }

--- a/ascii_mapper/KernelMath.cs
+++ b/ascii_mapper/KernelMath.cs
@@ -35,8 +35,9 @@ namespace ascii_mapper
         /// <param name="size">The number of elements in the kernel. Must be a positive integer.</param>
         /// <param name="sigma">The standard deviation of the Gaussian distribution. Must be greater than 0.</param>
         /// <returns>An array of doubles representing the normalized Gaussian kernel. The sum of all elements in the array is 1.</returns>
-        public static double[] GenerateGaussianKernel(int size, double sigma, int u = 0)
+        public static double[] GenerateGaussianKernel(int diameter, double sigma, int u = 0)
         {
+            int size = diameter * diameter;
             double normalizationSum = 0.0;
             double[] kernel = new double[size];
 

--- a/ascii_mapper/ascii_mapper.csproj
+++ b/ascii_mapper/ascii_mapper.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="GaussianKernel.cs" />
     <Compile Include="Interfaces\IFilter.cs" />
     <Compile Include="KernelMath.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
- Renamed `KernelMath.GenereateGaussianKernel()` parameter `size` to `diameter`
- Changed `KernelMath.GenerateGaussianKernel()` to include a new variable named `size` which is equal to $\text{diameter}^2$ (during creation of return array, this variable is used to determine the length)