### PR TITLE
[FIX(Bitmap class)]

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Change from `WinForms` to `WPF` caused `Bitmap` class reference to be lost. This fixes that.